### PR TITLE
[feat] Dynamic Vault Token Injection Via Vault Agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang as builder
+RUN mkdir -p /go/src/github.com/poisvin/kubernetes-vault-kms-plugin
+COPY . /go/src/github.com/poisvin/kubernetes-vault-kms-plugin/
+COPY ./vault-values.yaml /go/
+WORKDIR /go
+RUN go build -tags netgo -a -v github.com/poisvin/kubernetes-vault-kms-plugin/vault/server
+
+FROM alpine:latest
+COPY --from=builder /go/server /bin/k8s-kms-plugin
+COPY --from=builder /go/vault-values.yaml /
+CMD ["/bin/k8s-kms-plugin", "-socketFile=/var/run/kmsplugin/socket.sock", "-vaultConfig=/vault-values.yaml", "-tokenFile=/home/vault/.vault-token"]

--- a/README.md
+++ b/README.md
@@ -20,32 +20,42 @@ The Kubernetes KMS Plugin Provider for HashiCorp Vault has the following require
 * Kubernetes 1.10 or later
 * [Go](https://golang.org/) 1.9 or later
 
-# Building the KMS plugin provider for HashiCorp Vault
-To build the KMS plugin provider:
-```
-mkdir -p $GOHOME/github.com/oracle
-cd $GOHOME/github.com/oracle
-git clone git@github.com/oracle/kubernetes-vault-kms-plugin.git
-go install github.com/oracle/kubernetes-vault-kms-plugin/vault/server
-```
+# Enable Kubernetes authentication for Vault
+Follow step 1 and 2 from the Hashicorp's official Vault Agent [documentation](https://learn.hashicorp.com/vault/identity-access-management/vault-agent-k8s#step-1-create-a-service-account). 
+Note: Only thing to change from the setup provided in the above link is to create the service account and bindings in kube-system namespace instead of default.
 
-# Starting the KMS plugin provider for HashiCorp Vault  
+
+# Starting the KMS plugin provider for HashiCorp Vault inside your cluster
 Note: The KMS Plugin Provider for HashiCorp Vault must be running before starting the Kubernetes API server.
 
 To start the plugin provider:
-1. Create a `vault-plugin.yaml` configuration file as shown in the following sample, using values appropriate for your configuration.
+1. Create/Modify a `vault-values.yaml` configuration file as shown in the following sample, using values appropriate for your configuration.
 ```yaml
 keyNames:
-  - kube-secret-enc-key
+  - my-key
 transitPath: /transit
 ca-cert: /home/me/ca.cert
 addr: https://example.com:8200
-token: <token>
 ```
 
 2. Run the following command to start the plugin.
 ```
-$GOHOME/bin/server -socketFile=<location of socketfile.sock> -vaultConfig=<location of vault-plugin.yaml>
+docker build . -t user-name/vault-kms-plugin:tag_name
+```
+
+3. Push the image created to docker hub
+```
+docker push user-name/vault-kms-plugin:tag_name
+```
+
+4. Create the config map in kube-system name space
+```
+kubectl create configmap example-vault-agent-config --from-file=./configs-k8s/ -n kube-system
+```
+
+5. Update the pod.yaml with image name available on docker hub and create the pod in kube-system namespace, ensure that the socket file created is accessible by kube-api-server
+```
+kubectl apply --filename pod.yaml -n kube-system
 ```
 
 # Configuring the Kubernetes cluster for the KMS Plugin Provider for HashiCorp Vault
@@ -70,8 +80,46 @@ resources:
         cachesize: 100
     - identity: {}  
 ```
+
+4. If you use Rancher configuration goes as below, modify cluster.yaml
+```
+kube-api:
+      always_pull_images: false
+      extra_binds:
+        - '/var/run/kmsplugin/:/var/run/kmsplugin/'
+      pod_security_policy: false
+      secrets_encryption_config:
+        enabled: true
+        custom_config:
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+          - resources:
+            - secrets
+            providers:
+            - kms:
+                name: aws-encryption-provider
+                endpoint: unix:///var/run/kmsplugin/socket.sock
+                cachesize: 1000
+                timeout: 3s
+            - identity: {}
+      service_node_port_range: 30000-32767
+```
+
 See [Configuring the KMS provider](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#configuring-the-kms-provider).
 
 # Verifying the configuration
-You can verify the configuration by starting the Kubernetes API server and testing the features as described in  [Encrypting your data with the KMS provider](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#encrypting-your-data-with-the-kms-provider).
+If you can access the etcd node or etcd using etcdctl then try following below steps:
+1. Write a Kubernetes secret as below:
+```
+kubectl create secret generic secret1 --from-literal=Hello=World!!!
+```
 
+2. Using etcdctl try to access the secret as below, you should be able to see the secret stored in encrypted format
+```
+ETCDCTL_API=3 etcdctl get /registry/secrets/default/secret1
+```
+
+Else you can verify the configuration by starting the Kubernetes API server and testing the features as described in  [Encrypting your data with the KMS provider](https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/#encrypting-your-data-with-the-kms-provider).
+
+Note: The whole setup above ensures that your secrets are encrypted at rest in etcd, they can still be accessed via `kubectl get secret` command. Kubernetes does not allow the secrets to be encrypted when you run this command because `kubectl get secrets` makes the same API call that your pods make when they have to retrive the secret from etcd. Encryption at this level would mean your pods will also not be able to read the secrets.

--- a/configs-k8s/vault-agent-config.hcl
+++ b/configs-k8s/vault-agent-config.hcl
@@ -1,0 +1,18 @@
+# Uncomment this to have Agent run once (e.g. when running as an initContainer)
+exit_after_auth = true
+pid_file = "/home/vault/pidfile"
+
+auto_auth {
+    method "kubernetes" {
+        mount_path = "auth/kubernetes"
+        config = {
+            role = "example"
+        }
+    }
+
+    sink "file" {
+        config = {
+            path = "/home/vault/.vault-token"
+        }
+    }
+}

--- a/encrypconf.yaml
+++ b/encrypconf.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+- resources:
+- secrets
+providers:
+- kms:
+    name: myKmsPlugin
+    endpoint: unix:///tmp/socketfile.sock
+    cachesize: 100
+    timeout: 3s
+- identity: {}

--- a/encrypconf.yaml
+++ b/encrypconf.yaml
@@ -1,12 +1,21 @@
-apiVersion: apiserver.config.k8s.io/v1
-kind: EncryptionConfiguration
-resources:
-- resources:
-- secrets
-providers:
-- kms:
-    name: myKmsPlugin
-    endpoint: unix:///tmp/socketfile.sock
-    cachesize: 100
-    timeout: 3s
-- identity: {}
+kube-api:
+      always_pull_images: false
+      extra_binds:
+        - '/var/run/kmsplugin/:/var/run/kmsplugin/'
+      pod_security_policy: false
+      secrets_encryption_config:
+        enabled: true
+        custom_config:
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+          - resources:
+            - secrets
+            providers:
+            - kms:
+                name: aws-encryption-provider
+                endpoint: unix:///var/run/kmsplugin/socket.sock
+                cachesize: 1000
+                timeout: 3s
+            - identity: {}
+      service_node_port_range: 30000-32767

--- a/pod.yaml
+++ b/pod.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vault-kms-encryption-provider
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+spec:
+  serviceAccountName: vault-auth
+  initContainers:
+    # Vault container
+    - name: vault-agent-auth
+      image: vault
+
+      volumeMounts:
+        - name: config
+          mountPath: /etc/vault
+        - name: vault-token
+          mountPath: /home/vault
+
+      # This assumes Vault running on local host and K8s running in Minikube using VirtualBox
+      env:
+        - name: VAULT_ADDR
+          value: https://vault.example.com
+
+      # Run the Vault agent
+      args:
+        [
+          "agent",
+          "-config=/etc/vault/vault-agent-config.hcl",
+          #"-log-level=debug",
+        ]
+  containers:
+  - image: user-name/vault-kms-plugin:tag
+    imagePullPolicy: Always
+    name: vault-kms-encryption-provider
+    ports:
+    # - containerPort: 8080
+    #   protocol: TCP
+    # livenessProbe:
+    #   httpGet:
+    #     path: /healthz
+    #     port: 8080
+    volumeMounts:
+    - mountPath: /var/run/kmsplugin
+      name: var-run-kmsplugin
+    - mountPath: /home/vault
+      name: vault-token
+  volumes:
+  - name: var-run-kmsplugin
+    hostPath:
+      path: /var/run/kmsplugin
+      type: DirectoryOrCreate
+  - name: vault-token
+    emptyDir:
+      medium: Memory
+  - name: config
+    configMap:
+      name: example-vault-agent-config
+      items:
+        - key: vault-agent-config.hcl
+          path: vault-agent-config.hcl
+  tolerations:
+  - key: "node-role.kubernetes.io/controlplane"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/etcd"
+    operator: "Equal"
+    value: "true"
+    effect: "NoExecute"

--- a/token
+++ b/token
@@ -1,0 +1,1 @@
+s.jIQV7EAJT1S11MfY2bkxm9pV

--- a/vault-auth-service-account.yml
+++ b/vault-auth-service-account.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: role-tokenreview-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: kube-system

--- a/vault-plugin.yaml
+++ b/vault-plugin.yaml
@@ -1,0 +1,6 @@
+keyNames:
+  - my-key
+transitPath: /transit
+#ca-cert: /home/me/ca.cert
+addr: https://vault.ananthkamath.dev:8200
+token: s.GsX2Ml2ska8BCS7SrEzmvFWB

--- a/vault-plugin.yaml
+++ b/vault-plugin.yaml
@@ -1,6 +1,0 @@
-keyNames:
-  - my-key
-transitPath: /transit
-#ca-cert: /home/me/ca.cert
-addr: https://vault.ananthkamath.dev:8200
-token: s.GsX2Ml2ska8BCS7SrEzmvFWB

--- a/vault-values.yaml
+++ b/vault-values.yaml
@@ -1,0 +1,4 @@
+keyNames:
+  - my-key
+transitPath: /transit
+addr: https://vault.example.com:8200

--- a/vault/server/grpcServer.go
+++ b/vault/server/grpcServer.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
+	"string"
+	"io/ioutil"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
         pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
@@ -25,9 +27,10 @@ const (
 type CommandArgs struct {
 	socketFile            string
 	vaultConfig           string
+	tokenFile							string
 }
 
-var vaultServer *vault.VaultEnvelopeService 
+var vaultServer *vault.VaultEnvelopeService
 // server is used to implement kms plugin grpc server.
 type server struct{}
 
@@ -36,7 +39,7 @@ func (s *server) Version(ctx context.Context, request *pb.VersionRequest) (*pb.V
 	return &pb.VersionResponse{Version: "v1beta1", RuntimeName: "vault", RuntimeVersion: "0.1.0"}, nil
 }
 
-func (s *server) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb.DecryptResponse, error) { 
+func (s *server) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb.DecryptResponse, error) {
 	plain, err := vaultServer.Decrypt(request.Cipher)
 	if err != nil{
 		log.Warnf("Decrypt error: %v", err)
@@ -57,8 +60,9 @@ func (s *server) Encrypt(ctx context.Context, request *pb.EncryptRequest) (*pb.E
 func parseCmd() CommandArgs {
 	socketFile := flag.String("socketFile", "", "socket file that gRpc server listens to")
 	vaultConfig := flag.String("vaultConfig", "", "vault config file location")
+	tokenFile := flag.String("tokenFile", "", "vault token file location")
 	flag.Parse()
-	
+
 	if len(*socketFile) == 0 {
 		log.Fatal("socketFile parameter not specified")
 	}
@@ -67,11 +71,16 @@ func parseCmd() CommandArgs {
 		log.Fatal("vaultConfig parameter not specified")
         }
 
+  if len(*tokenFile) == 0 {
+		log.Fatal("vault token file path parameter not specified")
+  }
 
-        cmdArgs := CommandArgs{
+  cmdArgs := CommandArgs{
 		socketFile:            *socketFile,
 		vaultConfig:           *vaultConfig,
+		cmdArgs.tokenFile 		 *tokenFile
 	}
+
 	return cmdArgs
 }
 
@@ -79,7 +88,16 @@ func parseCmd() CommandArgs {
 func main() {
 	/**********************parse command line arguments*******************/
 	cmdArgs := parseCmd()
-      
+
+	token := ""
+	// read the vault token from the file
+	if len(cmdArgs.tokenFile) != 0 {
+		tokenFileContents, tokenerr := ioutil.ReadFile(cmdArgs.tokenFile)
+		if tokenerr != nil {
+			log.Fatalf(" failed to read token file")
+		}
+		token := string.TrimSuffix(string(tokenFileContents), "\n")
+	}
 
 	// TODO clean sock file first
 	err := unix.Unlink(cmdArgs.socketFile)
@@ -87,7 +105,7 @@ func main() {
 	if err != nil {
 		log.Fatal("failed to read config file")
 	}
-	vs, err2 := vault.KMSFactory(f)
+	vs, err2 := vault.KMSFactory(f, token)
 	if err2 != nil {
                 log.Fatalf("failed to initialize vault service, error: %v", err2)
         }
@@ -102,5 +120,5 @@ func main() {
         log.Infof("Version: %s, runtimeName: %s, RuntimeVersion: %s", "v1beta1", "vault", "0.1.0")
         if err := s.Serve(listener); err != nil {
                 log.Fatalf("failed to serve: %v", err)
-        }   
+        }
 }

--- a/vault/server/grpcServer.go
+++ b/vault/server/grpcServer.go
@@ -11,12 +11,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"net"
 	"os"
-	"string"
+	"strings"
 	"io/ioutil"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-        pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
-	"github.com/oracle/kubernetes-vault-kms-plugin/vault"
+  pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"github.com/poisvin/kubernetes-vault-kms-plugin/vault"
 	"golang.org/x/sys/unix"
 )
 
@@ -78,7 +78,7 @@ func parseCmd() CommandArgs {
   cmdArgs := CommandArgs{
 		socketFile:            *socketFile,
 		vaultConfig:           *vaultConfig,
-		cmdArgs.tokenFile 		 *tokenFile
+		tokenFile:				 		 *tokenFile,
 	}
 
 	return cmdArgs
@@ -96,7 +96,7 @@ func main() {
 		if tokenerr != nil {
 			log.Fatalf(" failed to read token file")
 		}
-		token := string.TrimSuffix(string(tokenFileContents), "\n")
+		token = strings.TrimSuffix(string(tokenFileContents), "\n")
 	}
 
 	// TODO clean sock file first

--- a/vault/vaultPlugin.go
+++ b/vault/vaultPlugin.go
@@ -59,7 +59,7 @@ type EnvelopeConfig struct {
 }
 
 // KMSFactory function creates Vault KMS service
-func KMSFactory(configFile io.Reader) (*VaultEnvelopeService, error) {
+func KMSFactory(configFile io.Reader, token string) (*VaultEnvelopeService, error) {
 	configFileContents, err := ioutil.ReadAll(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read contents: %v", err)
@@ -69,6 +69,10 @@ func KMSFactory(configFile io.Reader) (*VaultEnvelopeService, error) {
 	err = yaml.Unmarshal(configFileContents, &config)
 	if err != nil {
 		return nil, fmt.Errorf("error while parsing file: %v", err)
+	}
+
+	if len(token) !=0 {
+		config.Token = token
 	}
 
 	err = validateConfig(&config)


### PR DESCRIPTION
# Context
In its current setup the plugin has to be run as Go executable on the kubernetes master node, this is not a feasible solution as every time the node dies and comes back up you will have to SSH into the node and execute set of commands to make. the plugin work.

As this plugin is used in the world of Kubernetes we need the plugin to be dockerised and need to ensure that there is very minimal human or manual interaction. This PR will try to achieve the solution to above problem by containerising the plugin and using combination of Kubernetes Auth method on Vault with Vault agent setup as init container in the pod which will dynamically authenticate with Vault and provide the Vault auth token to Vault KMS Plugin container inside the pod.

# Changes
This PR includes below changes:
- Code change to include Vault token location as the third argument to the plugin
- Dockerfile to dockerise the plugin
- Config map required for Vault agent
- pod.yaml required to deploy the plugin as a pod
- Updates the readme to include steps explaining the new changes to implemented as part of the PR
